### PR TITLE
Sliding window counter

### DIFF
--- a/CONTRIBUTIONS.rst
+++ b/CONTRIBUTIONS.rst
@@ -5,3 +5,4 @@ Contributors
   - `Zehua Liu <https://github.com/zehua>`_
   - `David Czarnecki <https://github.com/czarneckid>`_
   - `Laurent Savaete <https://github.com/laurentS>`_
+  - `Antoine Merino <https://github.com/merinorus>`_

--- a/limits/aio/storage/base.py
+++ b/limits/aio/storage/base.py
@@ -179,3 +179,57 @@ class MovingWindowSupport(ABC):
         :return: (start of window, number of acquired entries)
         """
         raise NotImplementedError
+
+
+class SlidingWindowCounterSupport(ABC):
+    """
+    Abstract base for storages that intend to support
+    the sliding window counter strategy
+    """
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> SlidingWindowCounterSupport:  # type: ignore[misc]
+        inst = super().__new__(cls)
+
+        for method in {"acquire_sliding_window_entry", "get_sliding_window"}:
+            setattr(
+                inst,
+                method,
+                _wrap_errors(cast(Storage, inst), getattr(inst, method)),
+            )
+
+        return inst
+
+    @abstractmethod
+    async def acquire_sliding_window_entry(
+        self,
+        key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+    ) -> bool:
+        """
+        Acquire an entry. Shift the current window to the previous window if it expired.
+        :param current_window_key: current window key
+        :param previous_window_key: previous window key
+        :param limit: amount of entries allowed
+        :param expiry: expiry of the entry
+        :param amount: the number of entries to acquire
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_sliding_window(
+        self, key: str, expiry: int
+    ) -> tuple[int, float, int, float]:
+        """
+        Return the previous and current window information.
+        Return a tuple[int, float, int_ float] with the following information:
+        - previous window counter (int)
+        - previous window TTL (float)
+        - current window counter (int)
+        - current window TTL (float)
+
+        :param key: the rate limit key
+        :param expiry: the rate limit expiry, needed to compute the key in some implementations
+        """
+        raise NotImplementedError

--- a/limits/aio/storage/memcached.py
+++ b/limits/aio/storage/memcached.py
@@ -1,14 +1,17 @@
 import time
 import urllib.parse
+from math import ceil, floor
+from typing import Iterable
 
 from deprecated.sphinx import versionadded
 
-from limits.aio.storage.base import Storage
-from limits.typing import EmcacheClientP, Optional, Tuple, Type, Union
+from limits.aio.storage.base import SlidingWindowCounterSupport, Storage
+from limits.storage.base import TimestampedSlidingWindow
+from limits.typing import EmcacheClientP, ItemP, Optional, Tuple, Type, Union
 
 
 @versionadded(version="2.1")
-class MemcachedStorage(Storage):
+class MemcachedStorage(Storage, SlidingWindowCounterSupport, TimestampedSlidingWindow):
     """
     Rate limit storage with memcached as backend.
 
@@ -70,10 +73,18 @@ class MemcachedStorage(Storage):
         """
         :param key: the key to get the counter value for
         """
-
         item = await (await self.get_storage()).get(key.encode("utf-8"))
 
         return item and int(item.value) or 0
+
+    async def get_many(self, keys: Iterable[str]) -> dict[bytes, ItemP]:
+        """
+        Return multiple counters at once
+        :param key: the key to get the counter value for
+        """
+        return await (await self.get_storage()).get_many(
+            [k.encode("utf-8") for k in keys]
+        )
 
     async def clear(self, key: str) -> None:
         """
@@ -81,8 +92,31 @@ class MemcachedStorage(Storage):
         """
         await (await self.get_storage()).delete(key.encode("utf-8"))
 
+    async def decr(self, key: str, amount: int = 1, noreply: bool = False) -> int:
+        """
+        decrements the counter for a given rate limit key
+
+        retursn 0 if the key doesn't exist or if noreply is set to True
+
+        :param key: the key to decrement
+        :param amount: the number to decrement by
+        :param noreply: set to True to ignore the memcached response
+        """
+        storage = await self.get_storage()
+        limit_key = key.encode("utf-8")
+        try:
+            value = await storage.decrement(limit_key, amount, noreply=noreply) or 0
+        except self.dependency.NotFoundCommandError:
+            value = 0
+        return value
+
     async def incr(
-        self, key: str, expiry: int, elastic_expiry: bool = False, amount: int = 1
+        self,
+        key: str,
+        expiry: float,
+        elastic_expiry: bool = False,
+        amount: int = 1,
+        set_expiration_key: bool = True,
     ) -> int:
         """
         increments the counter for a given rate limit key
@@ -92,48 +126,69 @@ class MemcachedStorage(Storage):
         :param elastic_expiry: whether to keep extending the rate limit
          window every hit.
         :param amount: the number to increment by
+        :param set_expiration_key: if set to False, the expiration time won't be stored but the key will still expire
         """
         storage = await self.get_storage()
         limit_key = key.encode("utf-8")
-        expire_key = f"{key}/expires".encode()
-        added = True
+        expire_key = self._expiration_key(key).encode()
+        value = None
         try:
-            await storage.add(limit_key, f"{amount}".encode(), exptime=expiry)
-        except self.dependency.NotStoredStorageCommandError:
-            added = False
-            storage = await self.get_storage()
-
-        if not added:
             value = await storage.increment(limit_key, amount) or amount
-
             if elastic_expiry:
-                await storage.touch(limit_key, exptime=expiry)
-                await storage.set(
-                    expire_key,
-                    str(expiry + time.time()).encode("utf-8"),
-                    exptime=expiry,
-                    noreply=False,
-                )
-
+                await storage.touch(limit_key, exptime=ceil(expiry))
+                if set_expiration_key:
+                    await storage.set(
+                        expire_key,
+                        str(expiry + time.time()).encode("utf-8"),
+                        exptime=ceil(expiry),
+                        noreply=False,
+                    )
             return value
-        else:
-            await storage.set(
-                expire_key,
-                str(expiry + time.time()).encode("utf-8"),
-                exptime=expiry,
-                noreply=False,
-            )
-
-        return amount
+        except self.dependency.NotFoundCommandError:
+            # Incrementation failed because the key doesn't exist
+            storage = await self.get_storage()
+            try:
+                await storage.add(limit_key, f"{amount}".encode(), exptime=ceil(expiry))
+                if set_expiration_key:
+                    await storage.set(
+                        expire_key,
+                        str(expiry + time.time()).encode("utf-8"),
+                        exptime=ceil(expiry),
+                        noreply=False,
+                    )
+                value = amount
+            except self.dependency.NotStoredStorageCommandError:
+                # Coult not add the key, probably because a concurrent call has added it
+                storage = await self.get_storage()
+                value = await storage.increment(limit_key, amount) or amount
+                if elastic_expiry:
+                    await storage.touch(limit_key, exptime=ceil(expiry))
+                    if set_expiration_key:
+                        await storage.set(
+                            expire_key,
+                            str(expiry + time.time()).encode("utf-8"),
+                            exptime=ceil(expiry),
+                            noreply=False,
+                        )
+            return value
 
     async def get_expiry(self, key: str) -> float:
         """
         :param key: the key to get the expiry for
         """
         storage = await self.get_storage()
-        item = await storage.get(f"{key}/expires".encode())
+        item = await storage.get(self._expiration_key(key).encode("utf-8"))
 
         return item and float(item.value) or time.time()
+
+    def _expiration_key(self, key: str) -> str:
+        """
+        Return the expiration key for the given counter key.
+
+        Memcached doesn't natively return the expiration time or TTL for a given key,
+        so we implement the expiration time on a separate key.
+        """
+        return key + "/expires"
 
     async def check(self) -> bool:
         """
@@ -150,3 +205,81 @@ class MemcachedStorage(Storage):
 
     async def reset(self) -> Optional[int]:
         raise NotImplementedError
+
+    async def acquire_sliding_window_entry(
+        self,
+        key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+    ) -> bool:
+        if amount > limit:
+            return False
+        now = time.time()
+        previous_key, current_key = self.sliding_window_keys(key, expiry, now)
+        (
+            previous_count,
+            previous_ttl,
+            current_count,
+            _,
+        ) = await self._get_sliding_window_info(previous_key, current_key, expiry, now)
+        t0 = time.time()
+        weighted_count = previous_count * previous_ttl / expiry + current_count
+        if floor(weighted_count) + amount > limit:
+            return False
+        else:
+            # Hit, increase the current counter.
+            # If the counter doesn't exist yet, set twice the theorical expiry.
+            # We don't need the expiration key as it is estimated with the timestamps directly.
+            current_count = await self.incr(
+                current_key, 2 * expiry, amount=amount, set_expiration_key=False
+            )
+            t1 = time.time()
+            actualised_previous_ttl = max(0, previous_ttl - (t1 - t0))
+            weighted_count = (
+                previous_count * actualised_previous_ttl / expiry + current_count
+            )
+            if floor(weighted_count) > limit:
+                # Another hit won the race condition: revert the incrementation and refuse this hit
+                # Limitation: during high concurrency at the end of the window,
+                # the counter is shifted and cannot be decremented, so less requests than expected are allowed.
+                await self.decr(current_key, amount, noreply=True)
+                return False
+            return True
+
+    async def get_sliding_window(
+        self, key: str, expiry: int
+    ) -> tuple[int, float, int, float]:
+        now = time.time()
+        previous_key, current_key = self.sliding_window_keys(key, expiry, now)
+        return await self._get_sliding_window_info(
+            previous_key, current_key, expiry, now
+        )
+
+    async def _get_sliding_window_info(
+        self,
+        previous_key: str,
+        current_key: str,
+        expiry: Optional[int] = None,
+        now: Optional[float] = None,
+    ) -> tuple[int, float, int, float]:
+        if expiry is None:
+            raise ValueError("the expiry value is needed for this storage.")
+        if now is None:
+            now = time.time()
+        result = await self.get_many([previous_key, current_key])
+
+        raw_previous_count = result.get(previous_key.encode("utf-8"))
+        previous_count = raw_previous_count and int(raw_previous_count.value) or 0
+        raw_current_count = result.get(current_key.encode("utf-8"))
+        current_count = raw_current_count and int(raw_current_count.value) or 0
+
+        current_count = raw_current_count and int(raw_current_count.value) or 0
+        previous_count = raw_previous_count and int(raw_previous_count.value) or 0
+        if previous_count == 0:
+            previous_ttl = float(0)
+        else:
+            previous_ttl = (1 - (((now - expiry) / expiry) % 1)) * expiry
+        current_ttl = (1 - ((now / expiry) % 1)) * expiry + expiry
+
+        return previous_count, previous_ttl, current_count, current_ttl

--- a/limits/aio/storage/memory.py
+++ b/limits/aio/storage/memory.py
@@ -1,11 +1,17 @@
 import asyncio
 import time
 from collections import Counter
+from math import floor
 
 from deprecated.sphinx import versionadded
 
 import limits.typing
-from limits.aio.storage.base import MovingWindowSupport, Storage
+from limits.aio.storage.base import (
+    MovingWindowSupport,
+    SlidingWindowCounterSupport,
+    Storage,
+)
+from limits.storage.base import TimestampedSlidingWindow
 from limits.typing import Dict, List, Optional, Tuple, Type, Union
 
 
@@ -17,7 +23,9 @@ class LockableEntry(asyncio.Lock):
 
 
 @versionadded(version="2.1")
-class MemoryStorage(Storage, MovingWindowSupport):
+class MemoryStorage(
+    Storage, MovingWindowSupport, SlidingWindowCounterSupport, TimestampedSlidingWindow
+):
     """
     rate limit storage using :class:`collections.Counter`
     as an in memory storage for fixed and elastic window strategies,
@@ -62,7 +70,7 @@ class MemoryStorage(Storage, MovingWindowSupport):
             self.timer = asyncio.create_task(self.__expire_events())
 
     async def incr(
-        self, key: str, expiry: int, elastic_expiry: bool = False, amount: int = 1
+        self, key: str, expiry: float, elastic_expiry: bool = False, amount: int = 1
     ) -> int:
         """
         increments the counter for a given rate limit key
@@ -82,11 +90,22 @@ class MemoryStorage(Storage, MovingWindowSupport):
 
         return self.storage.get(key, amount)
 
+    async def decr(self, key: str, amount: int = 1) -> int:
+        """
+        decrements the counter for a given rate limit key. 0 is the minimum allowed value.
+
+        :param amount: the number to increment by
+        """
+        await self.get(key)
+        await self.__schedule_expiry()
+        self.storage[key] = max(self.storage[key] - amount, 0)
+
+        return self.storage.get(key, amount)
+
     async def get(self, key: str) -> int:
         """
         :param key: the key to get the counter value for
         """
-
         if self.expirations.get(key, 0) <= time.time():
             self.storage.pop(key, None)
             self.expirations.pop(key, None)
@@ -170,6 +189,78 @@ class MemoryStorage(Storage, MovingWindowSupport):
                 return item.atime, acquired
 
         return timestamp, acquired
+
+    async def acquire_sliding_window_entry(
+        self,
+        key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+    ) -> bool:
+        if amount > limit:
+            return False
+        now = time.time()
+        previous_key, current_key = self.sliding_window_keys(key, expiry, now)
+        (
+            previous_count,
+            previous_ttl,
+            current_count,
+            _,
+        ) = await self._get_sliding_window_info(previous_key, current_key, expiry, now)
+        weighted_count = previous_count * previous_ttl / expiry + current_count
+        if floor(weighted_count) + amount > limit:
+            return False
+        else:
+            # Hit, increase the current counter.
+            # If the counter doesn't exist yet, set twice the theorical expiry.
+            current_count = await self.incr(current_key, 2 * expiry, amount=amount)
+            weighted_count = previous_count * previous_ttl / expiry + current_count
+            if floor(weighted_count) > limit:
+                # Another hit won the race condition: revert the incrementation and refuse this hit
+                # Limitation: during high concurrency at the end of the window,
+                # the counter is shifted and cannot be decremented, so less requests than expected are allowed.
+                await self.decr(current_key, amount)
+                # print("Concurrent call, reverting the counter increase")
+                return False
+            return True
+
+    async def get_sliding_window(
+        self, key: str, expiry: int
+    ) -> Tuple[int, float, int, float]:
+        """
+        returns the starting point and the number of entries in the moving
+        window
+
+        :param key: rate limit key
+        :param expiry: expiry of entry
+        :return: (start of window, number of acquired entries)
+        """
+        now = time.time()
+        previous_key, current_key = self.sliding_window_keys(key, expiry, now)
+        return await self._get_sliding_window_info(
+            previous_key, current_key, expiry, now
+        )
+
+    async def _get_sliding_window_info(
+        self,
+        previous_key: str,
+        current_key: str,
+        expiry: Optional[int] = None,
+        now: Optional[float] = None,
+    ) -> tuple[int, float, int, float]:
+        if expiry is None:
+            raise ValueError("the expiry value is needed for this storage.")
+        if now is None:
+            now = time.time()
+
+        previous_count = await self.get(previous_key)
+        current_count = await self.get(current_key)
+        if previous_count == 0:
+            previous_ttl = float(0)
+        else:
+            previous_ttl = (1 - (((now - expiry) / expiry) % 1)) * expiry
+        current_ttl = (1 - ((now / expiry) % 1)) * expiry + expiry
+        return previous_count, previous_ttl, current_count, current_ttl
 
     async def check(self) -> bool:
         """

--- a/limits/aio/storage/redis.py
+++ b/limits/aio/storage/redis.py
@@ -5,7 +5,11 @@ from typing import TYPE_CHECKING, cast
 from deprecated.sphinx import versionadded
 from packaging.version import Version
 
-from limits.aio.storage.base import MovingWindowSupport, Storage
+from limits.aio.storage.base import (
+    MovingWindowSupport,
+    SlidingWindowCounterSupport,
+    Storage,
+)
 from limits.errors import ConfigurationError
 from limits.typing import AsyncRedisClient, Dict, Optional, Tuple, Type, Union
 from limits.util import get_package_data
@@ -24,9 +28,15 @@ class RedisInteractor:
     )
     SCRIPT_CLEAR_KEYS = get_package_data(f"{RES_DIR}/clear_keys.lua")
     SCRIPT_INCR_EXPIRE = get_package_data(f"{RES_DIR}/incr_expire.lua")
+    SCRIPT_SLIDING_WINDOW = get_package_data(f"{RES_DIR}/sliding_window.lua")
+    SCRIPT_ACQUIRE_SLIDING_WINDOW = get_package_data(
+        f"{RES_DIR}/acquire_sliding_window.lua"
+    )
 
     lua_moving_window: "coredis.commands.Script[bytes]"
-    lua_acquire_window: "coredis.commands.Script[bytes]"
+    lua_acquire_moving_window: "coredis.commands.Script[bytes]"
+    lua_sliding_window: "coredis.commands.Script[bytes]"
+    lua_acquire_sliding_window: "coredis.commands.Script[bytes]"
     lua_clear_keys: "coredis.commands.Script[bytes]"
     lua_incr_expire: "coredis.commands.Script[bytes]"
 
@@ -85,7 +95,7 @@ class RedisInteractor:
 
         :param key: rate limit key
         :param expiry: expiry of entry
-        :return: (start of window, number of acquired entries)
+        :return: (previous count, previous TTL, current count, current TTL)
         """
         key = self.prefixed_key(key)
         timestamp = time.time()
@@ -95,6 +105,31 @@ class RedisInteractor:
         if window:
             return float(window[0]), window[1]  # type: ignore
         return timestamp, 0
+
+    async def get_sliding_window(
+        self, key: str, expiry: int
+    ) -> Tuple[int, float, int, float]:
+        """
+        returns the sliding window statistics (previous and current windows)
+
+        :param key: rate limit key
+        :param expiry: expiry of entry
+        :return: (previous count, previous TTL, current count, current TTL)
+        """
+        previous_key = self.prefixed_key(self._previous_window_key(key))
+        current_key = self.prefixed_key(self._current_window_key(key))
+
+        window = await self.lua_sliding_window.execute(
+            [previous_key, current_key], [expiry]
+        )
+        if window:
+            return (
+                int(window[0] or 0),  # type: ignore
+                max(0, float(window[1] or 0)) / 1000,  # type: ignore
+                int(window[2] or 0),  # type: ignore
+                max(0, float(window[3] or 0)) / 1000,  # type: ignore
+            )
+        return 0, float(0), 0, float(0)
 
     async def _acquire_entry(
         self,
@@ -112,10 +147,25 @@ class RedisInteractor:
         """
         key = self.prefixed_key(key)
         timestamp = time.time()
-        acquired = await self.lua_acquire_window.execute(
+        acquired = await self.lua_acquire_moving_window.execute(
             [key], [timestamp, limit, expiry, amount]
         )
 
+        return bool(acquired)
+
+    async def _acquire_sliding_window_entry(
+        self,
+        previous_key: str,
+        current_key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+    ) -> bool:
+        previous_key = self.prefixed_key(previous_key)
+        current_key = self.prefixed_key(current_key)
+        acquired = await self.lua_acquire_sliding_window.execute(
+            [previous_key, current_key], [limit, expiry, amount]
+        )
         return bool(acquired)
 
     async def _get_expiry(self, key: str, connection: AsyncRedisClient) -> float:
@@ -140,9 +190,35 @@ class RedisInteractor:
         except:  # noqa
             return False
 
+    def _current_window_key(self, key: str) -> str:
+        """
+        Return the current window's storage key (Sliding window strategy)
+
+        Contrary to other strategies that have one key per rate limit item,
+        this strategy has two keys per rate limit item than must be on the same machine.
+        To keep the current key and the previous key on the same Redis cluster node,
+        curly braces are added.
+
+        Eg: "{constructed_key}"
+        """
+        return f"{{{key}}}"
+
+    def _previous_window_key(self, key: str) -> str:
+        """
+        Return the previous window's storage key (Sliding window strategy).
+
+        Curvy braces are added on the common pattern with the current window's key,
+        so the current and the previous key are stored on the same Redis cluster node.
+
+        Eg: "{constructed_key}/-1"
+        """
+        return f"{self._current_window_key(key)}/-1"
+
 
 @versionadded(version="2.1")
-class RedisStorage(RedisInteractor, Storage, MovingWindowSupport):
+class RedisStorage(
+    RedisInteractor, Storage, MovingWindowSupport, SlidingWindowCounterSupport
+):
     """
     Rate limit storage with redis as backend.
 
@@ -206,12 +282,16 @@ class RedisStorage(RedisInteractor, Storage, MovingWindowSupport):
     def initialize_storage(self, _uri: str) -> None:
         # all these methods are coroutines, so must be called with await
         self.lua_moving_window = self.storage.register_script(self.SCRIPT_MOVING_WINDOW)
-        self.lua_acquire_window = self.storage.register_script(
+        self.lua_acquire_moving_window = self.storage.register_script(
             self.SCRIPT_ACQUIRE_MOVING_WINDOW
         )
         self.lua_clear_keys = self.storage.register_script(self.SCRIPT_CLEAR_KEYS)
-        self.lua_incr_expire = self.storage.register_script(
-            RedisStorage.SCRIPT_INCR_EXPIRE
+        self.lua_incr_expire = self.storage.register_script(self.SCRIPT_INCR_EXPIRE)
+        self.lua_sliding_window = self.storage.register_script(
+            self.SCRIPT_SLIDING_WINDOW
+        )
+        self.lua_acquire_sliding_window = self.storage.register_script(
+            self.SCRIPT_ACQUIRE_SLIDING_WINDOW
         )
 
     async def incr(
@@ -260,6 +340,19 @@ class RedisStorage(RedisInteractor, Storage, MovingWindowSupport):
         """
 
         return await super()._acquire_entry(key, limit, expiry, self.storage, amount)
+
+    async def acquire_sliding_window_entry(
+        self,
+        key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+    ) -> bool:
+        current_key = self._current_window_key(key)
+        previous_key = self._previous_window_key(key)
+        return await super()._acquire_sliding_window_entry(
+            previous_key, current_key, limit, expiry, amount
+        )
 
     async def get_expiry(self, key: str) -> float:
         """

--- a/limits/resources/redis/lua_scripts/acquire_sliding_window.lua
+++ b/limits/resources/redis/lua_scripts/acquire_sliding_window.lua
@@ -1,0 +1,45 @@
+-- Time is in milliseconds in this script: TTL, expiry...
+
+local limit = tonumber(ARGV[1])
+local expiry = tonumber(ARGV[2]) * 1000
+local amount = tonumber(ARGV[3])
+
+if amount > limit then
+    return false
+end
+
+local current_ttl = tonumber(redis.call('pttl', KEYS[2]))
+
+if current_ttl > 0 and current_ttl < expiry then
+    -- Current window expired, shift it to the previous window
+    redis.call('rename', KEYS[2], KEYS[1])
+    redis.call('set', KEYS[2], 0, 'PX', current_ttl + expiry)
+end
+
+local previous_count = tonumber(redis.call('get', KEYS[1])) or 0
+local previous_ttl = tonumber(redis.call('pttl', KEYS[1])) or 0
+local current_count = tonumber(redis.call('get', KEYS[2])) or 0
+current_ttl = tonumber(redis.call('pttl', KEYS[2])) or 0
+
+-- If the values don't exist yet, consider the TTL is 0
+if previous_ttl <= 0 then
+    previous_ttl = 0
+end
+if current_ttl <= 0 then
+    current_ttl = 0
+end
+local weighted_count = math.floor(previous_count * previous_ttl / expiry) + current_count
+
+if (weighted_count + amount) > limit then
+    return false
+end
+
+-- If the current counter exists, increase its value
+if redis.call('exists', KEYS[2]) == 1 then
+    redis.call('incrby', KEYS[2], amount)
+else
+    -- Otherwise, set the value with twice the expiry time
+    redis.call('set', KEYS[2], amount, 'PX', expiry * 2)
+end
+
+return true

--- a/limits/resources/redis/lua_scripts/sliding_window.lua
+++ b/limits/resources/redis/lua_scripts/sliding_window.lua
@@ -1,0 +1,17 @@
+local expiry = tonumber(ARGV[1]) * 1000
+local previous_count = redis.call('get', KEYS[1])
+local previous_ttl = redis.call('pttl', KEYS[1])
+local current_count = redis.call('get', KEYS[2])
+local current_ttl = redis.call('pttl', KEYS[2])
+
+if current_ttl > 0 and current_ttl < expiry then
+    -- Current window expired, shift it to the previous window
+    redis.call('rename', KEYS[2], KEYS[1])
+    redis.call('set', KEYS[2], 0, 'PX', current_ttl + expiry)
+    previous_count = redis.call('get', KEYS[1])
+    previous_ttl = redis.call('pttl', KEYS[1])
+    current_count = redis.call('get', KEYS[2])
+    current_ttl = redis.call('pttl', KEYS[2])
+end
+
+return {previous_count, previous_ttl, current_count, current_ttl}

--- a/limits/storage/base.py
+++ b/limits/storage/base.py
@@ -171,3 +171,73 @@ class MovingWindowSupport(ABC):
         :return: (start of window, number of acquired entries)
         """
         raise NotImplementedError
+
+
+class SlidingWindowCounterSupport(ABC):
+    """
+    Abstract base for storages that intend to support
+    the sliding window counter strategy
+    """
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> SlidingWindowCounterSupport:  # type: ignore[misc]
+        inst = super().__new__(cls)
+
+        for method in {"acquire_sliding_window_entry", "get_sliding_window"}:
+            setattr(
+                inst,
+                method,
+                _wrap_errors(cast(Storage, inst), getattr(inst, method)),
+            )
+
+        return inst
+
+    @abstractmethod
+    def acquire_sliding_window_entry(
+        self, key: str, limit: int, expiry: int, amount: int = 1
+    ) -> bool:
+        """
+        Acquire an entry. Shift the current window to the previous window if it expired.
+        :param current_window_key: current window key
+        :param previous_window_key: previous window key
+        :param limit: amount of entries allowed
+        :param expiry: expiry of the entry
+        :param amount: the number of entries to acquire
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_sliding_window(
+        self, key: str, expiry: int
+    ) -> tuple[int, float, int, float]:
+        """
+        Return the previous and current window information.
+        This method should be implemented by the inherited classes if a more performant solution is available.
+        Return a tuple[int, float, int_ float] with the following information:
+        - previous window counter (int)
+        - previous window TTL (float)
+        - current window counter (int)
+        - current window TTL (float)
+        """
+        raise NotImplementedError
+
+
+class TimestampedSlidingWindow:
+    """Helper class for storage that support the sliding window counter, with timestamp based keys."""
+
+    @classmethod
+    def sliding_window_keys(cls, key: str, expiry: int, at: float) -> Tuple[str, str]:
+        """
+        returns the previous and the current window's keys.
+
+        :param key: the key to get the window's keys from
+        :param expiry: the expiry of the limit item, in seconds
+        :param at: tthe timestamp to get the keys from. Default to now, ie time.time()
+
+        Returns a tuple with the previous and the current key: (previous, current).
+        Example:
+            - key = "mykey"
+            - expiry = 60
+            - at = 1738576292.6631825
+        The return value will be the tuple ("mykey/28976271", "mykey/28976270").
+        """
+        return f"{key}/{int((at - expiry) / expiry)}", f"{key}/{int(at / expiry)}"

--- a/limits/storage/memcached.py
+++ b/limits/storage/memcached.py
@@ -2,11 +2,16 @@ import inspect
 import threading
 import time
 import urllib.parse
+from math import ceil, floor
 from types import ModuleType
-from typing import cast
+from typing import Any, Iterable, cast
 
 from limits.errors import ConfigurationError
-from limits.storage.base import Storage
+from limits.storage.base import (
+    SlidingWindowCounterSupport,
+    Storage,
+    TimestampedSlidingWindow,
+)
 from limits.typing import (
     Callable,
     List,
@@ -21,7 +26,7 @@ from limits.typing import (
 from limits.util import get_dependency
 
 
-class MemcachedStorage(Storage):
+class MemcachedStorage(Storage, SlidingWindowCounterSupport, TimestampedSlidingWindow):
     """
     Rate limit storage with memcached as backend.
 
@@ -142,8 +147,14 @@ class MemcachedStorage(Storage):
         """
         :param key: the key to get the counter value for
         """
+        return int(self.storage.get(key, "0"))
 
-        return int(self.storage.get(key) or 0)
+    def get_many(self, keys: Iterable[str]) -> dict[str, Any]:  # type:ignore[misc]
+        """
+        Return multiple counters at once
+        :param key: the key to get the counter value for
+        """
+        return self.storage.get_many(keys)
 
     def clear(self, key: str) -> None:
         """
@@ -152,7 +163,12 @@ class MemcachedStorage(Storage):
         self.storage.delete(key)
 
     def incr(
-        self, key: str, expiry: int, elastic_expiry: bool = False, amount: int = 1
+        self,
+        key: str,
+        expiry: float,
+        elastic_expiry: bool = False,
+        amount: int = 1,
+        set_expiration_key: bool = True,
     ) -> int:
         """
         increments the counter for a given rate limit key
@@ -162,41 +178,67 @@ class MemcachedStorage(Storage):
         :param elastic_expiry: whether to keep extending the rate limit
          window every hit.
         :param amount: the number to increment by
+        :param set_expiration_key: set the expiration key with the expiration time if needed. If set to False, the key will still expire, but memcached cannot provide the expiration time.
         """
-
-        if not self.call_memcached_func(
-            self.storage.add, key, amount, expiry, noreply=False
-        ):
-            value = self.storage.incr(key, amount) or amount
-
+        value = self.call_memcached_func(self.storage.incr, key, amount, noreply=False)
+        if value is not None:
             if elastic_expiry:
-                self.call_memcached_func(self.storage.touch, key, expiry)
-                self.call_memcached_func(
-                    self.storage.set,
-                    key + "/expires",
-                    expiry + time.time(),
-                    expire=expiry,
-                    noreply=False,
-                )
+                self.call_memcached_func(self.storage.touch, key, ceil(expiry))
+                if set_expiration_key:
+                    self.call_memcached_func(
+                        self.storage.set,
+                        self._expiration_key(key),
+                        expiry + time.time(),
+                        expire=ceil(expiry),
+                        noreply=False,
+                    )
 
             return value
         else:
-            self.call_memcached_func(
-                self.storage.set,
-                key + "/expires",
-                expiry + time.time(),
-                expire=expiry,
-                noreply=False,
-            )
+            if not self.call_memcached_func(
+                self.storage.add, key, amount, ceil(expiry), noreply=False
+            ):
+                value = self.storage.incr(key, amount) or amount
 
-        return amount
+                if elastic_expiry:
+                    self.call_memcached_func(self.storage.touch, key, ceil(expiry))
+                    if set_expiration_key:
+                        self.call_memcached_func(
+                            self.storage.set,
+                            self._expiration_key(key),
+                            expiry + time.time(),
+                            expire=ceil(expiry),
+                            noreply=False,
+                        )
+
+                return value
+            else:
+                if set_expiration_key:
+                    self.call_memcached_func(
+                        self.storage.set,
+                        self._expiration_key(key),
+                        expiry + time.time(),
+                        expire=ceil(expiry),
+                        noreply=False,
+                    )
+
+            return amount
 
     def get_expiry(self, key: str) -> float:
         """
         :param key: the key to get the expiry for
         """
 
-        return float(self.storage.get(key + "/expires") or time.time())
+        return float(self.storage.get(self._expiration_key(key)) or time.time())
+
+    def _expiration_key(self, key: str) -> str:
+        """
+        Return the expiration key for the given counter key.
+
+        Memcached doesn't natively return the expiration time or TTL for a given key,
+        so we implement the expiration time on a separate key.
+        """
+        return key + "/expires"
 
     def check(self) -> bool:
         """
@@ -212,3 +254,76 @@ class MemcachedStorage(Storage):
 
     def reset(self) -> Optional[int]:
         raise NotImplementedError
+
+    def acquire_sliding_window_entry(
+        self,
+        key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+    ) -> bool:
+        if amount > limit:
+            return False
+        now = time.time()
+        previous_key, current_key = self.sliding_window_keys(key, expiry, now)
+        previous_count, previous_ttl, current_count, _ = self._get_sliding_window_info(
+            previous_key, current_key, expiry, now=now
+        )
+        weighted_count = previous_count * previous_ttl / expiry + current_count
+        if floor(weighted_count) + amount > limit:
+            return False
+        else:
+            # Hit, increase the current counter.
+            # If the counter doesn't exist yet, set twice the theorical expiry.
+            # We don't need the expiration key as it is estimated with the timestamps directly.
+            current_count = self.incr(
+                current_key, 2 * expiry, amount=amount, set_expiration_key=False
+            )
+            actualised_previous_ttl = min(0, previous_ttl - (time.time() - now))
+            weighted_count = (
+                previous_count * actualised_previous_ttl / expiry + current_count
+            )
+            if floor(weighted_count) > limit:
+                # Another hit won the race condition: revert the incrementation and refuse this hit
+                # Limitation: during high concurrency at the end of the window,
+                # the counter is shifted and cannot be decremented, so less requests than expected are allowed.
+                self.call_memcached_func(
+                    self.storage.decr,
+                    current_key,
+                    amount,
+                    noreply=True,
+                )
+                return False
+            return True
+
+    def get_sliding_window(
+        self, key: str, expiry: int
+    ) -> tuple[int, float, int, float]:
+        now = time.time()
+        previous_key, current_key = self.sliding_window_keys(key, expiry, now)
+        return self._get_sliding_window_info(previous_key, current_key, expiry)
+
+    def _get_sliding_window_info(
+        self,
+        previous_key: str,
+        current_key: str,
+        expiry: Optional[int] = None,
+        now: Optional[float] = None,
+    ) -> tuple[int, float, int, float]:
+        if expiry is None:
+            raise ValueError("the expiry value is needed for this storage.")
+        if now is None:
+            now = time.time()
+
+        result = self.get_many([previous_key, current_key])
+        previous_count, current_count = (
+            int(result.get(previous_key, 0)),
+            int(result.get(current_key, 0)),
+        )
+
+        if previous_count == 0:
+            previous_ttl = float(0)
+        else:
+            previous_ttl = (1 - (((now - expiry) / expiry) % 1)) * expiry
+        current_ttl = (1 - ((now / expiry) % 1)) * expiry + expiry
+        return previous_count, previous_ttl, current_count, current_ttl

--- a/limits/storage/memory.py
+++ b/limits/storage/memory.py
@@ -1,9 +1,15 @@
 import threading
 import time
 from collections import Counter
+from math import floor
 
 import limits.typing
-from limits.storage.base import MovingWindowSupport, Storage
+from limits.storage.base import (
+    MovingWindowSupport,
+    SlidingWindowCounterSupport,
+    Storage,
+    TimestampedSlidingWindow,
+)
 from limits.typing import Dict, List, Optional, Tuple, Type, Union
 
 
@@ -14,7 +20,9 @@ class LockableEntry(threading._RLock):  # type: ignore
         super().__init__()
 
 
-class MemoryStorage(Storage, MovingWindowSupport):
+class MemoryStorage(
+    Storage, MovingWindowSupport, SlidingWindowCounterSupport, TimestampedSlidingWindow
+):
     """
     rate limit storage using :class:`collections.Counter`
     as an in memory storage for fixed and elastic window strategies,
@@ -58,7 +66,7 @@ class MemoryStorage(Storage, MovingWindowSupport):
             self.timer.start()
 
     def incr(
-        self, key: str, expiry: int, elastic_expiry: bool = False, amount: int = 1
+        self, key: str, expiry: float, elastic_expiry: bool = False, amount: int = 1
     ) -> int:
         """
         increments the counter for a given rate limit key
@@ -75,6 +83,19 @@ class MemoryStorage(Storage, MovingWindowSupport):
 
         if elastic_expiry or self.storage[key] == amount:
             self.expirations[key] = time.time() + expiry
+
+        return self.storage.get(key, 0)
+
+    def decr(self, key: str, amount: int = 1) -> int:
+        """
+        decrements the counter for a given rate limit key
+
+        :param key: the key to decrement
+        :param amount: the number to decrement by
+        """
+        self.get(key)
+        self.__schedule_expiry()
+        self.storage[key] = max(self.storage[key] - amount, 0)
 
         return self.storage.get(key, 0)
 
@@ -160,6 +181,76 @@ class MemoryStorage(Storage, MovingWindowSupport):
                 return item.atime, acquired
 
         return timestamp, acquired
+
+    def acquire_sliding_window_entry(
+        self,
+        key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+    ) -> bool:
+        if amount > limit:
+            return False
+        now = time.time()
+        previous_key, current_key = self.sliding_window_keys(key, expiry, now)
+        (
+            previous_count,
+            previous_ttl,
+            current_count,
+            _,
+        ) = self._get_sliding_window_info(previous_key, current_key, expiry, now)
+        weighted_count = previous_count * previous_ttl / expiry + current_count
+        if floor(weighted_count) + amount > limit:
+            return False
+        else:
+            # Hit, increase the current counter.
+            # If the counter doesn't exist yet, set twice the theorical expiry.
+            current_count = self.incr(current_key, 2 * expiry, amount=amount)
+            weighted_count = previous_count * previous_ttl / expiry + current_count
+            if floor(weighted_count) > limit:
+                # Another hit won the race condition: revert the incrementation and refuse this hit
+                # Limitation: during high concurrency at the end of the window,
+                # the counter is shifted and cannot be decremented, so less requests than expected are allowed.
+                self.decr(current_key, amount)
+                # print("Concurrent call, reverting the counter increase")
+                return False
+            return True
+
+    def _get_sliding_window_info(
+        self,
+        previous_key: str,
+        current_key: str,
+        expiry: Optional[int] = None,
+        now: Optional[float] = None,
+    ) -> tuple[int, float, int, float]:
+        if expiry is None:
+            raise ValueError("the expiry value is needed for this storage.")
+        if now is None:
+            now = time.time()
+
+        previous_count = self.get(previous_key)
+        current_count = self.get(current_key)
+        if previous_count == 0:
+            previous_ttl = float(0)
+        else:
+            previous_ttl = (1 - (((now - expiry) / expiry) % 1)) * expiry
+        current_ttl = (1 - ((now / expiry) % 1)) * expiry + expiry
+        return previous_count, previous_ttl, current_count, current_ttl
+
+    def get_sliding_window(
+        self, key: str, expiry: int
+    ) -> Tuple[int, float, int, float]:
+        """
+        returns the starting point and the number of entries in the moving
+        window
+
+        :param key: rate limit key
+        :param expiry: expiry of entry
+        :return: (start of window, number of acquired entries)
+        """
+        now = time.time()
+        previous_key, current_key = self.sliding_window_keys(key, expiry, now)
+        return self._get_sliding_window_info(previous_key, current_key, expiry, now)
 
     def check(self) -> bool:
         """

--- a/limits/strategies.py
+++ b/limits/strategies.py
@@ -2,8 +2,12 @@
 Rate limiting strategies
 """
 
+import time
 from abc import ABCMeta, abstractmethod
+from math import floor
 from typing import Dict, Type, Union, cast
+
+from limits.storage.base import SlidingWindowCounterSupport
 
 from .limits import RateLimitItem
 from .storage import MovingWindowSupport, Storage, StorageTypes
@@ -173,6 +177,109 @@ class FixedWindowRateLimiter(RateLimiter):
         return WindowStats(reset, remaining)
 
 
+class SlidingWindowCounterRateLimiter(RateLimiter):
+    """
+    Reference: :ref:`strategies:sliding window counter`
+    """
+
+    def __init__(self, storage: StorageTypes):
+        if not hasattr(storage, "get_sliding_window") or not hasattr(
+            storage, "acquire_sliding_window_entry"
+        ):
+            raise NotImplementedError(
+                "SlidingWindowCounterRateLimiting is not implemented for storage "
+                "of type %s" % storage.__class__
+            )
+        super().__init__(storage)
+
+    def _weighted_count(
+        self,
+        item: RateLimitItem,
+        previous_count: int,
+        previous_expires_in: float,
+        current_count: int,
+    ) -> float:
+        """
+        Return the approximated by weighting the previous window count and adding the current window count.
+        """
+        return previous_count * previous_expires_in / item.get_expiry() + current_count
+
+    def hit(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> bool:
+        """
+        Consume the rate limit
+
+        :param item: The rate limit item
+        :param identifiers: variable list of strings to uniquely identify this
+         instance of the limit
+        :param cost: The cost of this hit, default 1
+        """
+        return cast(
+            SlidingWindowCounterSupport, self.storage
+        ).acquire_sliding_window_entry(
+            item.key_for(*identifiers),
+            item.amount,
+            item.get_expiry(),
+            cost,
+        )
+
+    def test(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> bool:
+        """
+        Check if the rate limit can be consumed
+
+        :param item: The rate limit item
+        :param identifiers: variable list of strings to uniquely identify this
+         instance of the limit
+        :param cost: The expected cost to be consumed, default 1
+        """
+        previous_count, previous_expires_in, current_count, _ = cast(
+            SlidingWindowCounterSupport, self.storage
+        ).get_sliding_window(item.key_for(*identifiers), item.get_expiry())
+
+        return (
+            self._weighted_count(
+                item, previous_count, previous_expires_in, current_count
+            )
+            < item.amount - cost + 1
+        )
+
+    def get_window_stats(self, item: RateLimitItem, *identifiers: str) -> WindowStats:
+        """
+        Query the reset time and remaining amount for the limit.
+
+        :param item: The rate limit item
+        :param identifiers: variable list of strings to uniquely identify this
+         instance of the limit
+        :return: (reset time, remaining)
+        """
+        previous_count, previous_expires_in, current_count, current_expires_in = cast(
+            SlidingWindowCounterSupport, self.storage
+        ).get_sliding_window(item.key_for(*identifiers), item.get_expiry())
+        remaining = max(
+            0,
+            item.amount
+            - floor(
+                self._weighted_count(
+                    item, previous_count, previous_expires_in, current_count
+                )
+            ),
+        )
+        now = time.time()
+        if previous_count >= 1 and current_count == 0:
+            previous_window_reset_period = item.get_expiry() / previous_count
+            reset = previous_expires_in % previous_window_reset_period + now
+        elif previous_count >= 1 and current_count >= 1:
+            previous_window_reset_period = item.get_expiry() / previous_count
+            previous_reset = previous_expires_in % previous_window_reset_period + now
+            current_reset = current_expires_in % item.get_expiry() + now
+            reset = min(previous_reset, current_reset)
+        elif previous_count == 0 and current_count >= 1:
+            reset = current_expires_in % item.get_expiry() + now
+        else:
+            reset = now
+
+        return WindowStats(reset, remaining)
+
+
 class FixedWindowElasticExpiryRateLimiter(FixedWindowRateLimiter):
     """
     Reference: :ref:`strategies:fixed window with elastic expiry`
@@ -200,12 +307,14 @@ class FixedWindowElasticExpiryRateLimiter(FixedWindowRateLimiter):
 
 
 KnownStrategy = Union[
+    Type[SlidingWindowCounterRateLimiter],
     Type[FixedWindowRateLimiter],
     Type[FixedWindowElasticExpiryRateLimiter],
     Type[MovingWindowRateLimiter],
 ]
 
 STRATEGIES: Dict[str, KnownStrategy] = {
+    "sliding-window-counter": SlidingWindowCounterRateLimiter,
     "fixed-window": FixedWindowRateLimiter,
     "fixed-window-elastic-expiry": FixedWindowElasticExpiryRateLimiter,
     "moving-window": MovingWindowRateLimiter,

--- a/limits/typing.py
+++ b/limits/typing.py
@@ -4,6 +4,7 @@ from typing import (
     Awaitable,
     Callable,
     Dict,
+    Iterable,
     List,
     NamedTuple,
     Optional,
@@ -48,9 +49,15 @@ class EmcacheClientP(Protocol):
 
     async def get(self, key: bytes, return_flags: bool = False) -> Optional[ItemP]: ...
 
+    async def get_many(self, keys: Iterable[bytes]) -> dict[bytes, ItemP]: ...
+
     async def gets(self, key: bytes, return_flags: bool = False) -> Optional[ItemP]: ...
 
     async def increment(
+        self, key: bytes, value: int, *, noreply: bool = False
+    ) -> Optional[int]: ...
+
+    async def decrement(
         self, key: bytes, value: int, *, noreply: bool = False
     ) -> Optional[int]: ...
 
@@ -83,7 +90,18 @@ class MemcachedClientP(Protocol):
 
     def get(self, key: str, default: Optional[str] = None) -> bytes: ...
 
-    def incr(self, key: str, value: int, noreply: Optional[bool] = False) -> int: ...
+    def get_many(self, keys: Iterable[str]) -> dict[str, Any]: ...  # type:ignore[misc]
+
+    def incr(
+        self, key: str, value: int, noreply: Optional[bool] = False
+    ) -> Optional[int]: ...
+
+    def decr(
+        self,
+        key: str,
+        value: int,
+        noreply: Optional[bool] = False,
+    ) -> Optional[int]: ...
 
     def delete(self, key: str, noreply: Optional[bool] = None) -> Optional[bool]: ...
 

--- a/tests/aio/test_strategy.py
+++ b/tests/aio/test_strategy.py
@@ -1,4 +1,5 @@
 import time
+from math import ceil
 
 import pytest
 
@@ -7,6 +8,7 @@ from limits.aio.strategies import (
     FixedWindowElasticExpiryRateLimiter,
     FixedWindowRateLimiter,
     MovingWindowRateLimiter,
+    SlidingWindowCounterRateLimiter,
 )
 from limits.limits import (
     RateLimitItemPerHour,
@@ -14,11 +16,14 @@ from limits.limits import (
     RateLimitItemPerSecond,
 )
 from limits.storage import storage_from_string
+from limits.storage.base import TimestampedSlidingWindow
 from tests.utils import (
     async_all_storage,
     async_fixed_start,
     async_moving_window_storage,
+    async_sliding_window_counter_storage,
     async_window,
+    timestamp_based_key_ttl,
 )
 
 
@@ -114,6 +119,185 @@ class TestAsyncWindow:
         ).reset_time == pytest.approx(end + 2, 1e-2)
         assert not await limiter.hit(limit, "k2", cost=6)
 
+    @async_sliding_window_counter_storage
+    @async_fixed_start
+    async def test_sliding_window_counter(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = SlidingWindowCounterRateLimiter(storage)
+        limit = RateLimitItemPerSecond(10, 2)
+        if isinstance(storage, TimestampedSlidingWindow):
+            # Avoid testing the behaviour when the window is about to be reset
+            ttl = timestamp_based_key_ttl(limit)
+            if ttl < 0.5:
+                time.sleep(ttl)
+        async with async_window(1) as (start, _):
+            assert all([await limiter.hit(limit) for _ in range(0, 10)])
+        assert not await limiter.hit(limit)
+        assert (await limiter.get_window_stats(limit)).remaining == 0
+        assert (await limiter.get_window_stats(limit)).reset_time == pytest.approx(
+            start + 2, 1e-2
+        )
+
+    @async_sliding_window_counter_storage
+    async def test_sliding_window_counter_total_reset(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = SlidingWindowCounterRateLimiter(storage)
+        multiple = 10
+        period = 1
+        limit = RateLimitItemPerSecond(multiple, period)
+        assert (await limiter.get_window_stats(limit)).remaining == multiple
+        if isinstance(storage, TimestampedSlidingWindow):
+            # Avoid testing the behaviour when the window is about to be reset
+            ttl = timestamp_based_key_ttl(limit)
+            if ttl < 0.5:
+                time.sleep(ttl)
+        assert await limiter.hit(limit, cost=multiple)
+        assert not await limiter.hit(limit)
+        assert (await limiter.get_window_stats(limit)).remaining == 0
+        time.sleep(period * 2)
+        assert (await limiter.get_window_stats(limit)).remaining == multiple
+        assert (await limiter.get_window_stats(limit)).reset_time == pytest.approx(
+            time.time(), abs=1e-2
+        )
+
+    @async_sliding_window_counter_storage
+    async def test_sliding_window_counter_current_window(self, uri, args, fixture):
+        """Check the window stats when only the current window is filled"""
+        storage = storage_from_string(uri, **args)
+        limiter = SlidingWindowCounterRateLimiter(storage)
+        limit = RateLimitItemPerHour(2, 24)
+        if isinstance(storage, TimestampedSlidingWindow):
+            # Avoid testing the behaviour when the window is about to be reset
+            ttl = timestamp_based_key_ttl(limit)
+            if ttl < 0.5:
+                time.sleep(ttl)
+        assert await limiter.hit(limit)
+        now = time.time()
+        if isinstance(storage, TimestampedSlidingWindow):
+            expected_reset_time = now + timestamp_based_key_ttl(limit, now)
+        else:
+            expected_reset_time = now + 24 * 3600
+        assert (await limiter.get_window_stats(limit)).reset_time == pytest.approx(
+            expected_reset_time, 1e-2
+        )
+        assert (await limiter.get_window_stats(limit)).remaining == 1
+        assert await limiter.hit(limit)
+        assert not await limiter.hit(limit)
+
+    @async_sliding_window_counter_storage
+    @pytest.mark.flaky(max_runs=3)
+    async def test_sliding_window_counter_previous_window(self, uri, args, fixture):
+        """Check the window stats when the previous window is partially filled"""
+        storage = storage_from_string(uri, **args)
+        limiter = SlidingWindowCounterRateLimiter(storage)
+        limit = RateLimitItemPerSecond(5, 1)
+        sleep_margin = 0.001
+        if isinstance(storage, TimestampedSlidingWindow):
+            # Avoid testing the behaviour when the window is about to be reset
+            ttl = timestamp_based_key_ttl(limit)
+            if ttl < 0.3:
+                time.sleep(ttl + sleep_margin)
+        t0 = time.time()
+        previous_window_hits = 3
+        await limiter.hit(limit)
+        t1 = time.time()
+        for i in range(previous_window_hits - 1):
+            await limiter.hit(limit)
+        # Check the stats: only the current window is filled
+        if isinstance(storage, TimestampedSlidingWindow):
+            expected_reset_time = t0 + timestamp_based_key_ttl(limit, t0)
+        else:
+            expected_reset_time = t1 + 1
+        reset_time = (await limiter.get_window_stats(limit)).reset_time
+        assert reset_time == pytest.approx(expected_reset_time, abs=0.03)
+        assert (await limiter.get_window_stats(limit)).remaining == 2
+        # Wait for the next window
+        sleep_time = expected_reset_time - time.time() + sleep_margin
+        time.sleep(sleep_time)
+        # A new hit should be available immediately after window shift
+        # The limiter should reset in a fraction of a period, according to how many hits are in the previous window
+        reset_time = (await limiter.get_window_stats(limit)).reset_time
+        reset_in = reset_time - time.time()
+        assert reset_in == pytest.approx(
+            limit.get_expiry() / previous_window_hits, abs=0.03
+        )
+        assert (await limiter.get_window_stats(limit)).remaining == 3
+        assert await limiter.hit(limit)
+        assert await limiter.hit(limit)
+        for i in range(previous_window_hits):
+            # A new item hit should be freed by the previous window
+            t0 = time.time()
+            assert (await limiter.get_window_stats(limit)).remaining == 1
+            assert await limiter.hit(limit)
+            assert (await limiter.get_window_stats(limit)).remaining == 0
+            assert not await limiter.hit(limit)
+            # The previous window has 4 hits. The reset time should be in a 1/4 of the window expiry
+            reset_time = (await limiter.get_window_stats(limit)).reset_time
+            t1 = time.time()
+            reset_in = reset_time - time.time()
+            assert reset_in == pytest.approx(
+                limit.get_expiry() / previous_window_hits - (t1 - t0), abs=0.03
+            )
+            # Wait for the next hit available
+            time.sleep(reset_in + sleep_margin)
+
+    @async_sliding_window_counter_storage
+    @async_fixed_start
+    async def test_sliding_window_counter_empty_stats(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = SlidingWindowCounterRateLimiter(storage)
+        limit = RateLimitItemPerSecond(10, 2)
+        assert (await limiter.get_window_stats(limit)).remaining == 10
+        assert (await limiter.get_window_stats(limit)).reset_time == pytest.approx(
+            time.time(), 1e-2
+        )
+
+    @async_sliding_window_counter_storage
+    @async_fixed_start
+    async def test_sliding_window_counter_stats(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = SlidingWindowCounterRateLimiter(storage)
+        limit = RateLimitItemPerMinute(2)
+        if isinstance(storage, TimestampedSlidingWindow):
+            next_second_from_now = ceil(time.time())
+        assert await limiter.hit(limit, "key")
+        time.sleep(1)
+        assert await limiter.hit(limit, "key")
+        time.sleep(1)
+        assert not await limiter.hit(limit, "key")
+        assert (await limiter.get_window_stats(limit, "key")).remaining == 0
+        if isinstance(storage, TimestampedSlidingWindow):
+            # With timestamp-based key implementation,
+            # the reset time is periodic according to the worker's timestamp
+            reset_time = (await limiter.get_window_stats(limit, "key")).reset_time
+            expected_reset = int(
+                limit.get_expiry() - (next_second_from_now % limit.get_expiry())
+            )
+            assert reset_time - next_second_from_now == pytest.approx(
+                expected_reset, abs=1e-2
+            )
+        else:
+            assert (
+                await limiter.get_window_stats(limit, "key")
+            ).reset_time - time.time() == pytest.approx(58, 1e-2)
+
+    @async_sliding_window_counter_storage
+    @async_fixed_start
+    async def test_sliding_window_counter_multiple_cost(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = SlidingWindowCounterRateLimiter(storage)
+        limit = RateLimitItemPerMinute(10, 2)
+        if isinstance(storage, TimestampedSlidingWindow):
+            # Avoid testing the behaviour when the window is about to be reset
+            ttl = timestamp_based_key_ttl(limit)
+            if ttl < 0.5:
+                time.sleep(ttl)
+        assert not await limiter.hit(limit, "k1", cost=11)
+        assert await limiter.hit(limit, "k2", cost=5)
+        assert (await limiter.get_window_stats(limit, "k2")).remaining == 5
+        assert not await limiter.test(limit, "k2", cost=6)
+        assert not await limiter.hit(limit, "k2", cost=6)
+
     @async_moving_window_storage
     async def test_moving_window(self, uri, args, fixture):
         storage = storage_from_string(uri, **args)
@@ -206,6 +390,17 @@ class TestAsyncWindow:
         storage = storage_from_string(uri, **args)
         limit = RateLimitItemPerHour(2, 1)
         limiter = MovingWindowRateLimiter(storage)
+        assert await limiter.hit(limit)
+        assert await limiter.test(limit)
+        assert await limiter.hit(limit)
+        assert not await limiter.test(limit)
+        assert not await limiter.hit(limit)
+
+    @async_sliding_window_counter_storage
+    async def test_test_sliding_window_counter(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limit = RateLimitItemPerHour(2, 1)
+        limiter = SlidingWindowCounterRateLimiter(storage)
         assert await limiter.hit(limit)
         assert await limiter.test(limit)
         assert await limiter.hit(limit)

--- a/tests/benchmarks/test_storage.py
+++ b/tests/benchmarks/test_storage.py
@@ -6,12 +6,18 @@ import pytest
 import limits.aio.strategies
 from limits import RateLimitItemPerMinute
 from limits.storage import storage_from_string
-from limits.strategies import FixedWindowRateLimiter, MovingWindowRateLimiter
+from limits.strategies import (
+    FixedWindowRateLimiter,
+    MovingWindowRateLimiter,
+    SlidingWindowCounterRateLimiter,
+)
 from tests.utils import (
     all_storage,
     async_all_storage,
     async_moving_window_storage,
+    async_sliding_window_counter_storage,
     moving_window_storage,
+    sliding_window_counter_storage,
 )
 
 
@@ -33,6 +39,18 @@ def test_fixed_window(benchmark, uri, args, fixture):
     benchmark(
         functools.partial(
             hit_window, FixedWindowRateLimiter, storage_from_string(uri, **args)
+        )
+    )
+
+
+@sliding_window_counter_storage
+@pytest.mark.benchmark(group="sliding-window-counter")
+def test_sliding_window_counter(benchmark, uri, args, fixture):
+    benchmark(
+        functools.partial(
+            hit_window,
+            SlidingWindowCounterRateLimiter,
+            storage_from_string(uri, **args),
         )
     )
 
@@ -68,6 +86,19 @@ def test_moving_window_async(event_loop, benchmark, uri, args, fixture):
             hit_window_async,
             event_loop,
             limits.aio.strategies.MovingWindowRateLimiter,
+            storage_from_string(uri, **args),
+        )
+    )
+
+
+@async_sliding_window_counter_storage
+@pytest.mark.benchmark(group="async-sliding-window-counter")
+def test_sliding_window_counter_async(event_loop, benchmark, uri, args, fixture):
+    benchmark(
+        functools.partial(
+            hit_window_async,
+            event_loop,
+            limits.aio.strategies.SlidingWindowCounterRateLimiter,
             storage_from_string(uri, **args),
         )
     )

--- a/tests/integration/test_concurrency.py
+++ b/tests/integration/test_concurrency.py
@@ -6,15 +6,20 @@ from uuid import uuid4
 
 import pytest
 
+import limits.aio.storage.memory
 import limits.aio.strategies
 import limits.strategies
 from limits.limits import RateLimitItemPerMinute
 from limits.storage import storage_from_string
+from limits.storage.base import TimestampedSlidingWindow
 from tests.utils import (
     all_storage,
     async_all_storage,
     async_moving_window_storage,
+    async_sliding_window_counter_storage,
     moving_window_storage,
+    sliding_window_counter_storage,
+    timestamp_based_key_ttl,
 )
 
 
@@ -37,6 +42,28 @@ class TestConcurrency:
                 hits.append(None)
 
         threads = [threading.Thread(target=hit) for _ in range(50)]
+        [t.start() for t in threads]
+        [t.join() for t in threads]
+
+        assert len(hits) == 5
+
+    @sliding_window_counter_storage
+    def test_sliding_window_counter(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = limits.strategies.SlidingWindowCounterRateLimiter(storage)
+        limit = RateLimitItemPerMinute(5)
+
+        [limiter.hit(limit, uuid4().hex) for _ in range(100)]
+
+        key = uuid4().hex
+        hits = []
+
+        def hit():
+            time.sleep(random.random() / 1000)
+            if limiter.hit(limit, key):
+                hits.append(None)
+
+        threads = [threading.Thread(target=hit) for _ in range(100)]
         [t.start() for t in threads]
         [t.join() for t in threads]
 
@@ -85,6 +112,29 @@ class TestAsyncConcurrency:
                 hits.append(None)
 
         await asyncio.gather(*[hit() for _ in range(50)])
+
+        assert len(hits) == 5
+
+    @async_sliding_window_counter_storage
+    async def test_sliding_window_counter(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = limits.aio.strategies.SlidingWindowCounterRateLimiter(storage)
+        limit = RateLimitItemPerMinute(5)
+        if isinstance(storage, TimestampedSlidingWindow):
+            # Avoid testing the behaviour when the window is about to be reset
+            ttl = timestamp_based_key_ttl(limit)
+            if ttl < 1:
+                time.sleep(ttl)
+
+        key = uuid4().hex
+        hits = []
+
+        async def hit():
+            await asyncio.sleep(random.random() / 1000)
+            if await limiter.hit(limit, key):
+                hits.append(None)
+
+        await asyncio.gather(*[hit() for _ in range(100)])
 
         assert len(hits) == 5
 

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,4 +1,5 @@
 import time
+from math import ceil
 
 import pytest
 
@@ -8,12 +9,21 @@ from limits.limits import (
     RateLimitItemPerSecond,
 )
 from limits.storage import MemcachedStorage, storage_from_string
+from limits.storage.base import TimestampedSlidingWindow
 from limits.strategies import (
     FixedWindowElasticExpiryRateLimiter,
     FixedWindowRateLimiter,
     MovingWindowRateLimiter,
+    SlidingWindowCounterRateLimiter,
 )
-from tests.utils import all_storage, fixed_start, moving_window_storage, window
+from tests.utils import (
+    all_storage,
+    fixed_start,
+    moving_window_storage,
+    sliding_window_counter_storage,
+    timestamp_based_key_ttl,
+    window,
+)
 
 
 class TestWindow:
@@ -88,6 +98,168 @@ class TestWindow:
         assert limiter.get_window_stats(limit, "k2").reset_time == pytest.approx(
             end + 2, 1e-2
         )
+        assert not limiter.hit(limit, "k2", cost=6)
+
+    @sliding_window_counter_storage
+    @fixed_start
+    def test_sliding_window_counter(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = SlidingWindowCounterRateLimiter(storage)
+        limit = RateLimitItemPerSecond(10, 2)
+        if isinstance(storage, TimestampedSlidingWindow):
+            next_second_from_now = ceil(time.time())
+            if next_second_from_now % 2 == 0:
+                # Next second is even, so the curent one is odd.
+                # Must wait a full period for memcached.
+                time.sleep(1)
+                next_second_from_now = ceil(time.time())
+        with window(1) as (start, end):
+            assert all([limiter.hit(limit) for _ in range(0, 10)])
+        assert not limiter.hit(limit)
+        assert limiter.get_window_stats(limit).remaining == 0
+        if isinstance(storage, TimestampedSlidingWindow):
+            # If the key is timestamp-based, the reset time is periodic according to the worker's timestamp
+            reset_time = limiter.get_window_stats(limit).reset_time
+            expected_reset = int(
+                limit.get_expiry() - (next_second_from_now % limit.get_expiry())
+            )
+            assert reset_time - next_second_from_now == pytest.approx(
+                expected_reset, abs=1e-2
+            )
+        else:
+            assert limiter.get_window_stats(limit).reset_time == pytest.approx(
+                start + 2, 1e-2
+            )
+
+    @sliding_window_counter_storage
+    def test_sliding_window_counter_total_reset(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = SlidingWindowCounterRateLimiter(storage)
+        multiple = 10
+        period = 1
+        limit = RateLimitItemPerSecond(multiple, period)
+        assert limiter.get_window_stats(limit).remaining == multiple
+        if isinstance(storage, TimestampedSlidingWindow):
+            # Avoid testing the behaviour when the window is about to be reset
+            ttl = timestamp_based_key_ttl(limit)
+            if ttl < 0.5:
+                time.sleep(ttl)
+        assert limiter.hit(limit, cost=multiple)
+        assert not limiter.hit(limit)
+        assert limiter.get_window_stats(limit).remaining == 0
+        time.sleep(period * 2)
+        assert limiter.get_window_stats(limit).remaining == multiple
+        assert limiter.get_window_stats(limit).reset_time == pytest.approx(
+            time.time(), abs=1e-2
+        )
+
+    @sliding_window_counter_storage
+    def test_sliding_window_counter_current_window(self, uri, args, fixture):
+        """Check the window stats when only the current window is filled"""
+        storage = storage_from_string(uri, **args)
+        limiter = SlidingWindowCounterRateLimiter(storage)
+        limit = RateLimitItemPerHour(2, 24)
+        if isinstance(storage, TimestampedSlidingWindow):
+            # Avoid testing the behaviour when the window is about to be reset
+            ttl = timestamp_based_key_ttl(limit)
+            if ttl < 0.5:
+                time.sleep(ttl)
+        assert limiter.hit(limit)
+        now = time.time()
+        if isinstance(storage, TimestampedSlidingWindow):
+            expected_reset_time = now + timestamp_based_key_ttl(limit, now)
+        else:
+            expected_reset_time = now + 24 * 3600
+        assert limiter.get_window_stats(limit).reset_time == pytest.approx(
+            expected_reset_time, 1e-2
+        )
+        assert limiter.get_window_stats(limit).remaining == 1
+        assert limiter.hit(limit)
+        assert not limiter.hit(limit)
+
+    @sliding_window_counter_storage
+    @pytest.mark.flaky(max_runs=3)
+    def test_sliding_window_counter_previous_window(self, uri, args, fixture):
+        """Check the window stats when the previous window is partially filled"""
+        storage = storage_from_string(uri, **args)
+        limiter = SlidingWindowCounterRateLimiter(storage)
+        period = 1
+        limit = RateLimitItemPerSecond(5, period)
+        sleep_margin = 0.001
+        if isinstance(storage, TimestampedSlidingWindow):
+            # Avoid testing the behaviour when the window is about to be reset
+            ttl = timestamp_based_key_ttl(limit)
+            if ttl < 0.3:
+                time.sleep(ttl + sleep_margin)
+        previous_window_hits = 3
+        for i in range(previous_window_hits):
+            limiter.hit(limit)
+        now = time.time()
+        # Check the stats: only the current window is filled
+        assert limiter.get_window_stats(limit).remaining == 2
+        if isinstance(storage, TimestampedSlidingWindow):
+            expected_reset_time = now + timestamp_based_key_ttl(limit, now)
+        else:
+            expected_reset_time = now + period
+        assert limiter.get_window_stats(limit).reset_time == pytest.approx(
+            expected_reset_time, 1e-2
+        )
+        # Wait for the next window
+        sleep_time = expected_reset_time - time.time() + sleep_margin
+        time.sleep(sleep_time)
+        # A new hit should be available immediately after window shift
+        # The limiter should reset in a fraction of a period, according to how many hits are in the previous window
+        reset_time = limiter.get_window_stats(limit).reset_time
+        reset_in = reset_time - time.time()
+        assert reset_in == pytest.approx(
+            limit.get_expiry() / previous_window_hits, abs=0.03
+        )
+        assert limiter.get_window_stats(limit).remaining == 3
+        assert limiter.hit(limit)
+        assert limiter.hit(limit)
+        for i in range(previous_window_hits):
+            # A new item hit should be freed by the previous window
+            t0 = time.time()
+            assert limiter.get_window_stats(limit).remaining == 1
+            assert limiter.hit(limit)
+            assert limiter.get_window_stats(limit).remaining == 0
+            assert not limiter.hit(limit)
+            # The previous window has 4 hits. The reset time should be in a 1/4 of the window expiry
+            reset_time = limiter.get_window_stats(limit).reset_time
+            t1 = time.time()
+            reset_in = reset_time - time.time()
+            assert reset_in == pytest.approx(
+                limit.get_expiry() / previous_window_hits - (t1 - t0), abs=0.03
+            )
+            # Wait for the next hit available
+            time.sleep(reset_in + sleep_margin)
+
+    @sliding_window_counter_storage
+    @fixed_start
+    def test_sliding_window_counter_empty_stats(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = SlidingWindowCounterRateLimiter(storage)
+        limit = RateLimitItemPerSecond(10, 2)
+        assert limiter.get_window_stats(limit).remaining == 10
+        assert limiter.get_window_stats(limit).reset_time == pytest.approx(
+            time.time(), 1e-2
+        )
+
+    @sliding_window_counter_storage
+    @fixed_start
+    def test_sliding_window_counter_multiple_cost(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = SlidingWindowCounterRateLimiter(storage)
+        limit = RateLimitItemPerMinute(10, 2)
+        if isinstance(storage, TimestampedSlidingWindow):
+            # Avoid testing the behaviour when the window is about to be reset
+            ttl = timestamp_based_key_ttl(limit)
+            if ttl < 0.5:
+                time.sleep(ttl)
+        assert not limiter.hit(limit, "k1", cost=11)
+        assert limiter.hit(limit, "k2", cost=5)
+        assert limiter.get_window_stats(limit, "k2").remaining == 5
+        assert not limiter.test(limit, "k2", cost=6)
         assert not limiter.hit(limit, "k2", cost=6)
 
     @moving_window_storage
@@ -184,6 +356,19 @@ class TestWindow:
     def test_test_fixed_window(self, uri, args, fixture):
         storage = storage_from_string(uri, **args)
         limiter = FixedWindowRateLimiter(storage)
+        limit = RateLimitItemPerHour(2, 1)
+        assert limiter.hit(limit)
+        assert limiter.test(limit)
+        assert limiter.hit(limit)
+        assert not limiter.test(limit)
+        assert not limiter.hit(limit)
+
+    @sliding_window_counter_storage
+    @fixed_start
+    @pytest.mark.flaky
+    def test_test_sliding_window_counter(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = SlidingWindowCounterRateLimiter(storage)
         limit = RateLimitItemPerHour(2, 1)
         assert limiter.hit(limit)
         assert limiter.test(limit)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,6 +8,8 @@ from typing import Optional
 import pytest
 from pytest_lazy_fixtures import lf
 
+from limits.limits import RateLimitItem
+
 
 def fixed_start(fn):
     @functools.wraps(fn)
@@ -20,6 +22,21 @@ def fixed_start(fn):
         return fn(*a, **k)
 
     return __inner
+
+
+def timestamp_based_key_ttl(item: RateLimitItem, now: Optional[float] = None) -> float:
+    """
+    Return the current timestamp-based key TTL.
+
+    Used for some implementations of thesliding window counter that generates keys based on the timestamp.
+
+    Args:
+        item (RateLimitItem): the rate limit item
+        now (Optional[float], optional): the current timestamp. If None, generates the current timestamp
+    """
+    if now is None:
+        now = time.time()
+    return item.get_expiry() - (now % item.get_expiry())
 
 
 def async_fixed_start(fn):
@@ -193,6 +210,68 @@ moving_window_storage = pytest.mark.parametrize(
     ],
 )
 
+sliding_window_counter_storage = pytest.mark.parametrize(
+    "uri, args, fixture",
+    [
+        pytest.param("memory://", {}, None, id="in-memory"),
+        pytest.param(
+            "redis://localhost:7379",
+            {},
+            lf("redis_basic"),
+            marks=pytest.mark.redis,
+            id="redis",
+        ),
+        pytest.param(
+            "memcached://localhost:22122",
+            {},
+            lf("memcached"),
+            marks=[pytest.mark.memcached, pytest.mark.flaky],
+            id="memcached",
+        ),
+        pytest.param(
+            "memcached://localhost:22122,localhost:22123",
+            {},
+            lf("memcached_cluster"),
+            marks=[pytest.mark.memcached, pytest.mark.flaky],
+            id="memcached-cluster",
+        ),
+        pytest.param(
+            "redis+cluster://localhost:7001/",
+            {},
+            lf("redis_cluster"),
+            marks=pytest.mark.redis_cluster,
+            id="redis-cluster",
+        ),
+        pytest.param(
+            "redis+cluster://:sekret@localhost:8400/",
+            {},
+            lf("redis_auth_cluster"),
+            marks=pytest.mark.redis_cluster,
+            id="redis-cluster-auth",
+        ),
+        pytest.param(
+            "redis+cluster://localhost:8301",
+            {
+                "ssl": True,
+                "ssl_cert_reqs": "required",
+                "ssl_keyfile": "./tests/tls/client.key",
+                "ssl_certfile": "./tests/tls/client.crt",
+                "ssl_ca_certs": "./tests/tls/ca.crt",
+            },
+            lf("redis_ssl_cluster"),
+            marks=pytest.mark.redis_cluster,
+            id="redis-ssl-cluster",
+        ),
+        pytest.param(
+            "redis+sentinel://localhost:26379/mymaster",
+            {"use_replicas": False},
+            lf("redis_sentinel"),
+            marks=pytest.mark.redis_sentinel,
+            id="redis-sentinel",
+        ),
+    ],
+)
+
 async_all_storage = pytest.mark.parametrize(
     "uri, args, fixture",
     [
@@ -324,6 +403,68 @@ async_moving_window_storage = pytest.mark.parametrize(
             lf("mongodb"),
             marks=pytest.mark.mongodb,
             id="mongodb",
+        ),
+    ],
+)
+
+async_sliding_window_counter_storage = pytest.mark.parametrize(
+    "uri, args, fixture",
+    [
+        pytest.param("async+memory://", {}, None, id="in-memory"),
+        pytest.param(
+            "async+redis://localhost:7379",
+            {},
+            lf("redis_basic"),
+            marks=pytest.mark.redis,
+            id="redis",
+        ),
+        pytest.param(
+            "async+memcached://localhost:22122",
+            {},
+            lf("memcached"),
+            marks=[pytest.mark.memcached, pytest.mark.flaky],
+            id="memcached",
+        ),
+        pytest.param(
+            "async+memcached://localhost:22122,localhost:22123",
+            {},
+            lf("memcached_cluster"),
+            marks=[pytest.mark.memcached, pytest.mark.flaky],
+            id="memcached-cluster",
+        ),
+        pytest.param(
+            "async+redis+cluster://localhost:7001/",
+            {},
+            lf("redis_cluster"),
+            marks=pytest.mark.redis_cluster,
+            id="redis-cluster",
+        ),
+        pytest.param(
+            "async+redis+cluster://:sekret@localhost:8400/",
+            {},
+            lf("redis_auth_cluster"),
+            marks=pytest.mark.redis_cluster,
+            id="redis-cluster-auth",
+        ),
+        pytest.param(
+            "async+redis+cluster://localhost:8301",
+            {
+                "ssl": True,
+                "ssl_cert_reqs": "required",
+                "ssl_keyfile": "./tests/tls/client.key",
+                "ssl_certfile": "./tests/tls/client.crt",
+                "ssl_ca_certs": "./tests/tls/ca.crt",
+            },
+            lf("redis_ssl_cluster"),
+            marks=pytest.mark.redis_cluster,
+            id="redis-ssl-cluster",
+        ),
+        pytest.param(
+            "async+redis+sentinel://localhost:26379/mymaster",
+            {"use_replicas": False},
+            lf("redis_sentinel"),
+            marks=pytest.mark.redis_sentinel,
+            id="redis-sentinel",
         ),
     ],
 )


### PR DESCRIPTION
Following discussion https://github.com/alisaifee/limits/discussions/245

Sliding window counter implementation.
Supported backends: in-memory, redis, memcached.

TODO:
- [x] Floor the weighted counter to avoid premature rate limit. update documentation.
- [x] Memcached: implementation is sensitive to clock drift between limiter workers (time sync is mandatory)
- [ ] How to emulate slow IO (get, incr...) for any storage in tests?
- [ ] Memcached: why setting noreply=True leads to worse IOPS?
- [x] Memcached: remove expiry counter creation (not needed) to increase performance
- [x] In-memory (async): concurrency problem, can allow more requests than expected -> timestamp-based keys fix this issue
- [x] in-memory (sync): check if the window shift is ok against high concurrency / multi threaded environment. Otherwise use the timestamp based keys -> timestamp-based keys like the async version
- [x] Add tests: reset time memcached/other, weighted counter, concurrency?
- [x] compute reset time (different if memcached or other)
- [x] Remove test application, remove comments, clean code
- [x] Squash in one commit
